### PR TITLE
not compatible with kubelet 1.22.1

### DIFF
--- a/roles/k8s/templates/ingress-nginx/Makefile
+++ b/roles/k8s/templates/ingress-nginx/Makefile
@@ -5,7 +5,7 @@ all: ingress-nginx.yaml
 ingress-nginx.yaml:
 	helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 	helm repo update
-	helm template kube-ingress-nginx ingress-nginx/ingress-nginx --version 3.36.0 -n kube-ingress-nginx -f values.yaml | cat > ingress-nginx.yaml
+	helm template kube-ingress-nginx ingress-nginx/ingress-nginx -n kube-ingress-nginx -f values.yaml | cat > ingress-nginx.yaml
 
 clean:
 	rm -f ingress-nginx.yaml


### PR DESCRIPTION
ingress-nginx v1.0.0 is compatible with k8s 1.22.1
please see Support Version Table:
https://github.com/kubernetes/ingress-nginx